### PR TITLE
[Anya] I fixed the code injection vulnerability in `introduction/mitre

### DIFF
--- a/introduction/mitre.py
+++ b/introduction/mitre.py
@@ -1,4 +1,6 @@
+import ast
 import datetime
+import operator
 import re
 import subprocess
 from hashlib import md5
@@ -210,12 +212,45 @@ def csrf_transfer_monei_api(request,recipent,amount):
         return redirect ('/mitre/9/lab/transaction')
 
 
+_SAFE_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+    ast.USub: operator.neg,
+    ast.UAdd: operator.pos,
+}
+
+
+def _safe_eval(node):
+    if isinstance(node, ast.Expression):
+        return _safe_eval(node.body)
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return node.value
+    if isinstance(node, ast.BinOp) and type(node.op) in _SAFE_OPERATORS:
+        return _SAFE_OPERATORS[type(node.op)](_safe_eval(node.left), _safe_eval(node.right))
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _SAFE_OPERATORS:
+        return _SAFE_OPERATORS[type(node.op)](_safe_eval(node.operand))
+    raise ValueError("Unsupported or unsafe expression")
+
+
+def safe_calculate(expression):
+    parsed = ast.parse(expression, mode='eval')
+    return _safe_eval(parsed)
+
+
 # @authentication_decorator
 @csrf_exempt
 def mitre_lab_25_api(request):
     if request.method == "POST":
         expression = request.POST.get('expression')
-        result = eval(expression)
+        try:
+            result = safe_calculate(expression)
+        except (ValueError, SyntaxError, TypeError, ZeroDivisionError):
+            return JsonResponse({'result': 'Invalid expression'}, status=400)
         return JsonResponse({'result': result})
     else:
         return redirect('/mitre/25/lab/')


### PR DESCRIPTION
## ArmorCode Anya — automated fix

**Finding:** 3873469252 — tainted-code-stdlib-django : Improper Control of Generation of Code ('Code Injection')
**File:** introduction/mitre.py:218

### Changes
I fixed the code injection vulnerability in `introduction/mitre.py` at `mitre_lab_25_api` (line 218), which called `eval()` directly on untrusted user input (`request.POST.get('expression')`), allowing arbitrary Python code execution.

**Fix:** Replaced `eval(expression)` with a `safe_calculate()` helper that parses the expression via `ast.parse(..., mode='eval')` and recursively evaluates only a whitelisted set of AST nodes — numeric constants and basic arithmetic operators (`+ - * / // % **` and unary +/-). Any other construct (function calls, attribute access, imports, comprehensions, etc.) raises `ValueError` and is caught, returning a 400 JSON error instead of executing anything.

This preserves the lab's intended functionality (a basic calculator) while eliminating the ability to execute arbitrary code, since only numeric literals and arithmetic operations are permitted.

Generated by ArmorCode Anya for finding 3873469252.
