### PR TITLE
[Anya] I fixed the "missing-user-entrypoint" finding by adding a non-r

### DIFF
--- a/dockerized_labs/sensitive_data_exposure/Dockerfile
+++ b/dockerized_labs/sensitive_data_exposure/Dockerfile
@@ -12,6 +12,12 @@ COPY . .
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Create a non-root user and give it ownership of the app directory
+# (needed since migrations write to the sqlite db under /app at runtime)
+RUN useradd --create-home --shell /bin/sh appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
 EXPOSE 8000
 
 # Use the entrypoint script


### PR DESCRIPTION
## ArmorCode Anya — automated fix

**Finding:** 3873469254 — missing-user-entrypoint : Improper Privilege Management
**File:** dockerized_labs/sensitive_data_exposure/Dockerfile:18

### Changes
I fixed the "missing-user-entrypoint" finding by adding a non-root user in `dockerized_labs/sensitive_data_exposure/Dockerfile`:

- Created a dedicated `appuser` account (`useradd --create-home --shell /bin/sh appuser`) and `chown -R`'d `/app` to it, since the entrypoint runs Django migrations that need write access to `db.sqlite3` under `/app`.
- Added `USER appuser` before `EXPOSE`/`ENTRYPOINT`, so the container process (and the resulting `entrypoint.sh` → `manage.py runserver`) runs as an unprivileged user instead of `root`, addressing the improper privilege management finding.

Generated by ArmorCode Anya for finding 3873469254.
